### PR TITLE
feat(kamiwaza): MCP-tool registrar (passthrough) — companion to agent-locksmith #89

### DIFF
--- a/docs/user/kamiwaza-mcp.md
+++ b/docs/user/kamiwaza-mcp.md
@@ -101,10 +101,11 @@ tracks Kamiwaza's live tool set.
 
 ### Per-tool MCP path
 
-The MCP mount point is genuinely **per-tool** and the registrar resolves it (never
-assumes): explicit `MCP_PATH` env wins; otherwise tools with `strip_path_prefix: true`
-(e.g. `kamiwaza-dde`) serve MCP at the route **root**, and the rest default to `/mcp`
-(e.g. omniparse-style). Use `KAMIWAZA_MCP_PATH_<SLUG>` to override a specific tool.
+The registrar resolves each tool's MCP sub-path: explicit `MCP_PATH` (deployment env,
+then template `env_defaults`) wins; otherwise it defaults to `/mcp`. Confirmed live
+against `kamiwaza-dde` — even with `strip_path_prefix: true` and no `MCP_PATH`, the MCP
+server mounts at `/mcp` (root 404s), so `/mcp` is the right default. Use
+`KAMIWAZA_MCP_PATH_<SLUG>` to override a specific tool that genuinely differs.
 
 ## Verify
 

--- a/docs/user/kamiwaza-mcp.md
+++ b/docs/user/kamiwaza-mcp.md
@@ -1,0 +1,132 @@
+# Kamiwaza MCP tools through locksmith
+
+Make Kamiwaza-hosted MCP tools reachable by your agents **through locksmith**, so
+the calls inherit per-agent ACL, audit, egress (pipelock), and response controls —
+the same plane every other tool gets. No locksmith code is involved: a Kamiwaza MCP
+tool is an ordinary `kind=tool` catalog registration, created and refreshed by a
+small **registrar** that runs off the request hot path.
+
+```
+MCP-client agent ──bearer──▶ locksmith /api/kamiwaza-<tool>/ ──PAT──▶ Kamiwaza MCP endpoint
+                              (auth → ACL → inject PAT → stream → audit)
+
+           registrar (cron) ──discovers──▶ Kamiwaza /tool/deployments + /extensions
+                            ──registers──▶ locksmith catalog (kind=tool, provider=kamiwaza)
+```
+
+## Why this shape
+
+MCP-over-HTTP is just JSON-RPC over HTTP POST, and Kamiwaza MCP endpoints accept the
+**same Kamiwaza bearer** the discovery API uses (`KAMIWAZA_USE_AUTH=true`). So a
+Kamiwaza MCP tool registered as a normal catalog entry —
+
+- `upstream` = the tool's MCP endpoint URL
+- `auth` = `bearer=KAMIWAZA_MCP_PAT` (locksmith injects it)
+- `egress` = `direct` (LAN Kamiwaza) or `proxied` (+ a pipelock allowlist entry)
+
+— is proxied transparently by locksmith's existing hot path. An MCP-client agent
+(e.g. hermes) speaks MCP straight through `/api/kamiwaza-<tool>/`; locksmith strips the
+agent's auth, injects the PAT, and forwards. `Mcp-Session-Id` and `text/event-stream`
+round-trip through the proxy, so MCP session continuity and streaming work unchanged.
+
+The **only** Kamiwaza-specific component is discovery — turning the live MCP servers
+into registrations. That lives in the registrar (cron-driven), so the discovery cost
+and its outbound-trust surface never touch agent traffic.
+
+> This supersedes the original in-core approach (agent-locksmith PR #89), which put a
+> Kamiwaza-specific provider on locksmith's hot path and re-implemented (and partly
+> skipped) the audit/egress/size-cap machinery. As registrations, Kamiwaza tools get
+> all of it for free, and locksmith stays vendor-neutral. The in-core path only made
+> sense for *non-MCP* agents calling MCP tools as plain REST (a translation layer we
+> deliberately did not adopt — our agents are MCP clients).
+
+## Prerequisites
+
+1. **A Kamiwaza PAT** for locksmith. Mint a durable one (admin scope, up to 1 year):
+
+   ```bash
+   # Authenticate (form body), then create a PAT.
+   TOKEN=$(curl -sk https://<kamiwaza-host>/api/auth/token \
+       -d "username=<user>&password=<pass>" | jq -r .access_token)
+   curl -sk https://<kamiwaza-host>/api/auth/pats -H "Authorization: Bearer $TOKEN" \
+       -H 'Content-Type: application/json' \
+       -d '{"name":"agent-locksmith-mcp","ttl_seconds":31536000,"scope":"admin","aud":"kamiwaza-platform"}' \
+       | jq -r .token
+   # The token is shown ONCE — store it immediately.
+   ```
+
+2. **The PAT in locksmith's container env.** Registrations reference
+   `--auth bearer=KAMIWAZA_MCP_PAT`, and locksmith resolves env vars from its own
+   process environment at registration time. Put the PAT in the site `.env` and forward
+   it by name in `docker-compose.override.yml`'s locksmith `environment:` list, then
+   **recreate locksmith before the first registrar run** (same pattern as the other
+   injected bearers):
+
+   ```yaml
+   # docker-compose.override.yml → services.locksmith.environment
+   KAMIWAZA_MCP_PAT: ${KAMIWAZA_MCP_PAT:-}
+   ```
+
+## Run the registrar
+
+```bash
+KAMIWAZA_API_URL=https://<kamiwaza-host> \
+KAMIWAZA_MCP_PAT=<pat> \
+LOCKSMITH_OP_TOKEN=$(./scripts/decrypt-creds.sh locksmith/secrets/operator_token.creds) \
+  ./scripts/kamiwaza-mcp-registrar.py --dry-run    # preview first
+```
+
+Drop `--dry-run` to apply. Each pass:
+
+- discovers live MCP tools from `/api/tool/deployments` (Tool Shed) and `/api/extensions`,
+- resolves each tool's external MCP URL and its per-tool MCP path (see below),
+- creates/updates a `kamiwaza-<slug>` registration (`metadata: provider=kamiwaza`),
+- **removes** registrations whose tool is no longer running.
+
+It's idempotent — schedule it via cron (e.g. every minute or two) so the catalog
+tracks Kamiwaza's live tool set.
+
+### Configuration (env)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `KAMIWAZA_API_URL` | — (required) | Kamiwaza base URL |
+| `KAMIWAZA_MCP_PAT` | — (required) | discovery bearer; **also** set in locksmith's env |
+| `KAMIWAZA_PAT_ENV` | `KAMIWAZA_MCP_PAT` | env-var NAME locksmith injects as the upstream bearer |
+| `KAMIWAZA_EGRESS` | `direct` | `direct` (LAN) or `proxied` (+ pipelock allowlist) |
+| `KAMIWAZA_TIMEOUT_REQUEST` | `600` | per-registration total-stream timeout (MCP calls can be long) |
+| `KAMIWAZA_MCP_PATH` | `/mcp` | fallback MCP sub-path |
+| `KAMIWAZA_MCP_PATH_<SLUG>` | — | per-tool MCP-path override |
+| `KAMIWAZA_VERIFY_TLS` | `true` | discovery TLS verification (disable only for dev self-signed) |
+
+### Per-tool MCP path
+
+The MCP mount point is genuinely **per-tool** and the registrar resolves it (never
+assumes): explicit `MCP_PATH` env wins; otherwise tools with `strip_path_prefix: true`
+(e.g. `kamiwaza-dde`) serve MCP at the route **root**, and the rest default to `/mcp`
+(e.g. omniparse-style). Use `KAMIWAZA_MCP_PATH_<SLUG>` to override a specific tool.
+
+## Verify
+
+```bash
+# The discovered tools appear as catalog registrations:
+docker exec layer8-locksmith locksmith tool list | grep kamiwaza-
+
+# An MCP-client agent allowlisted to the tool reaches it through locksmith:
+#   base = http://<proxy-host>:9200/api/kamiwaza-<slug>/
+# initialize → tools/list → tools/call round-trip, PAT injected, audited.
+```
+
+Audit rows for Kamiwaza tool calls carry `tool: kamiwaza-<slug>` and the calling
+agent's identity, like any other registration.
+
+## Notes / current limits
+
+- **MCP-client agents only.** Agents call these tools by speaking MCP through
+  locksmith. Non-MCP agents would need a translation layer (not provided here).
+- **Tool images must actually expose MCP.** Some Kamiwaza tool images are MCP-tagged
+  but REST-only (omniparse 2.2.0); `kamiwaza-dde` is genuinely MCP-native. The registrar
+  registers whatever is live and reachable — confirm a new tool's `upstream` resolves
+  to a working MCP endpoint after first registration.
+- **Egress.** For a LAN Kamiwaza, `direct` matches the `lmstudio` precedent. For an
+  internet-reachable Kamiwaza, use `proxied` and add the host to pipelock's allowlist.

--- a/docs/user/kamiwaza-mcp.md
+++ b/docs/user/kamiwaza-mcp.md
@@ -67,6 +67,24 @@ and its outbound-trust surface never touch agent traffic.
    KAMIWAZA_MCP_PAT: ${KAMIWAZA_MCP_PAT:-}
    ```
 
+3. **Trust Kamiwaza's CA in locksmith** (HTTPS upstream behind a private CA).
+   Kamiwaza serves its MCP endpoints over HTTPS with an internal CA (e.g. "Kamiwaza
+   Application Intermediate CA"). locksmith's HTTP client uses rustls + webpki bundled
+   roots, which ignore the system store, so it will not verify that cert unless the CA
+   is named explicitly. Mount the Kamiwaza CA bundle into the locksmith container and
+   point `tls.upstream_ca_bundle` at it (agent-locksmith ≥ v2.7.0):
+
+   ```yaml
+   # locksmith config.yaml
+   tls:
+     upstream_ca_bundle: "/etc/locksmith/ca/kamiwaza-ca.pem"
+   ```
+
+   The bundle needs the cert(s) that anchor the chain — trusting the intermediate is
+   enough to verify the endpoint. Extract it with:
+   `echo | openssl s_client -connect <kamiwaza-host>:443 -servername <kamiwaza-host> -showcerts | awk '/BEGIN CERT/,/END CERT/'`
+   (keep the intermediate / root, drop the leaf). Verification is never disabled.
+
 ## Run the registrar
 
 ```bash
@@ -107,19 +125,38 @@ against `kamiwaza-dde` — even with `strip_path_prefix: true` and no `MCP_PATH`
 server mounts at `/mcp` (root 404s), so `/mcp` is the right default. Use
 `KAMIWAZA_MCP_PATH_<SLUG>` to override a specific tool that genuinely differs.
 
+## Agent-facing URL
+
+The registration's **upstream is the tool's base runtime URL** (no MCP path), because
+locksmith's `/api/{tool}/{*path}` route requires a path segment. The agent's MCP client
+points at:
+
+```
+${layer8_endpoint}/api/kamiwaza-<slug><mcp_path>     # e.g. .../api/kamiwaza-dde/mcp
+```
+
+locksmith forwards `<mcp_path>` onto the base upstream and injects the PAT. The resolved
+`<mcp_path>` is stored on the registration as `metadata.mcp_path` (default `/mcp`).
+
 ## Verify
 
 ```bash
 # The discovered tools appear as catalog registrations:
 docker exec layer8-locksmith locksmith tool list | grep kamiwaza-
 
-# An MCP-client agent allowlisted to the tool reaches it through locksmith:
-#   base = http://<proxy-host>:9200/api/kamiwaza-<slug>/
+# An MCP-client agent allowlisted to the tool reaches it through locksmith at
+#   ${layer8_endpoint}/api/kamiwaza-<slug>/mcp
 # initialize → tools/list → tools/call round-trip, PAT injected, audited.
 ```
 
 Audit rows for Kamiwaza tool calls carry `tool: kamiwaza-<slug>` and the calling
 agent's identity, like any other registration.
+
+> **Validated live (2026-06-13)** against the running `kamiwaza-dde` tool: an MCP
+> `initialize → notifications/initialized → tools/list` round-trip through a locksmith
+> built with the `tls.upstream_ca_bundle` feature succeeded — TLS verified against the
+> Kamiwaza private CA, the PAT was injected (dummy client bearer stripped), the
+> `Mcp-Session-Id` round-tripped, and all 36 DDE tools were returned.
 
 ## Notes / current limits
 

--- a/examples/site/scripts/kamiwaza-mcp-registrar.py
+++ b/examples/site/scripts/kamiwaza-mcp-registrar.py
@@ -169,25 +169,24 @@ def _mcp_path_override(slug: str) -> str | None:
 def resolve_mcp_path(
     env: dict[str, Any], template: dict[str, Any] | None, override: str | None
 ) -> str:
-    """Resolve a tool's MCP sub-path. The MCP mount point is genuinely
-    per-tool — DDE serves MCP at the route ROOT via strip_path_prefix,
-    while omniparse-style tools declare MCP_PATH=/mcp — so this must be
-    resolved, never assumed. Precedence:
+    """Resolve a tool's MCP sub-path. Precedence:
       1. operator override (KAMIWAZA_MCP_PATH_<SLUG>),
       2. explicit MCP_PATH in the deployment env,
       3. explicit MCP_PATH in the template env_defaults,
-      4. strip_path_prefix tools → root (empty),
-      5. DEFAULT_MCP_PATH (/mcp)."""
+      4. DEFAULT_MCP_PATH (/mcp).
+    NOTE: do NOT special-case strip_path_prefix → root. Confirmed live
+    against kamiwaza-dde (strip_path_prefix=true, no MCP_PATH): the MCP
+    server still mounts at /mcp (root 404s, /mcp 200s) — strip_path_prefix
+    only governs Traefik prefix stripping, not the in-container MCP mount.
+    So /mcp is the right default; use the per-tool override for genuine
+    exceptions."""
     if override is not None:
         return override
     if "MCP_PATH" in env:
         return env["MCP_PATH"]
-    tmpl = template or {}
-    tmpl_env = tmpl.get("env_defaults") or {}
+    tmpl_env = (template or {}).get("env_defaults") or {}
     if "MCP_PATH" in tmpl_env:
         return tmpl_env["MCP_PATH"]
-    if tmpl.get("strip_path_prefix"):
-        return ""
     return DEFAULT_MCP_PATH
 
 

--- a/examples/site/scripts/kamiwaza-mcp-registrar.py
+++ b/examples/site/scripts/kamiwaza-mcp-registrar.py
@@ -99,7 +99,13 @@ class McpTool:
     Extensions sources."""
 
     slug: str  # locksmith registration name suffix ([a-z0-9-])
-    mcp_url: str  # externally-reachable MCP endpoint URL (the upstream)
+    # The registration upstream is the tool's BASE runtime URL (no MCP
+    # sub-path). locksmith's /api/{tool}/{*path} route requires a path
+    # segment, so the agent reaches MCP at /api/<reg><mcp_path> and
+    # locksmith forwards <mcp_path> onto this base. (Validated live
+    # against kamiwaza-dde: base upstream + agent call /api/<reg>/mcp.)
+    upstream: str  # externally-reachable BASE runtime URL
+    mcp_path: str  # MCP sub-path the agent appends (e.g. /mcp)
     source: str  # "tool-shed" | "extension"
     source_id: str  # deployment id / extension name (for audit metadata)
     description: str
@@ -133,14 +139,6 @@ def slugify(name: str) -> str:
     s = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
     s = re.sub(r"-{2,}", "-", s)
     return s or "tool"
-
-
-def _external_mcp_url(base_external: str, mcp_path: str) -> str:
-    """Join a tool's external base URL with its MCP path. An empty
-    mcp_path means MCP is served at the route root (strip_path_prefix
-    tools); return the base with a trailing slash."""
-    base = base_external.rstrip("/")
-    return f"{base}/" if not mcp_path.strip("/") else f"{base}/{mcp_path.lstrip('/')}"
 
 
 _TEMPLATE_CACHE: dict[str, dict[str, Any]] | None = None
@@ -207,23 +205,23 @@ def discover_tool_shed() -> list[McpTool]:
         env = dep.get("env_vars") or {}
         template = _tool_templates().get(str(dep.get("template_id", "")))
         mcp_path = resolve_mcp_path(env, template, _mcp_path_override(slugify(name)))
-        # Prefer an https external URL if the API provides one; else build
-        # the Traefik runtime route from the deployment name.
+        # The registration upstream is the BASE runtime URL (no MCP path).
+        # Prefer the API's https external url; else build the Traefik route.
         raw_url = dep.get("url", "")
         if raw_url.startswith("https://") and "host.docker.internal" not in raw_url:
-            mcp_url = (
-                raw_url
-                if raw_url.rstrip("/").endswith(mcp_path.strip("/"))
-                else _external_mcp_url(raw_url, mcp_path)
-            )
+            base = raw_url.rstrip("/")
+            # If the API already embedded the MCP path, strip it back to base.
+            suffix = mcp_path.strip("/")
+            if suffix and base.endswith(f"/{suffix}"):
+                base = base[: -(len(suffix) + 1)]
         else:
             runtime_name = dep.get("runtime_name") or f"{name}-{dep_id.split('-')[0]}"
             base = f"{KAMIWAZA_API_URL}/runtime/tools/{runtime_name}"
-            mcp_url = _external_mcp_url(base, mcp_path)
         tools.append(
             McpTool(
                 slug=slugify(name),
-                mcp_url=mcp_url,
+                upstream=base,
+                mcp_path=mcp_path,
                 source="tool-shed",
                 source_id=str(dep_id),
                 description=dep.get("description") or f"Kamiwaza Tool Shed MCP: {name}",
@@ -256,7 +254,8 @@ def discover_extensions() -> list[McpTool]:
         tools.append(
             McpTool(
                 slug=slugify(name),
-                mcp_url=_external_mcp_url(external, mcp_path),
+                upstream=external.rstrip("/"),
+                mcp_path=mcp_path,
                 source="extension",
                 source_id=name,
                 description=ext.get("description") or f"Kamiwaza extension MCP: {name}",
@@ -312,12 +311,15 @@ def existing_kamiwaza_registrations() -> set[str]:
 
 
 def put_registration(name: str, tool: McpTool, dry_run: bool) -> None:
+    # Agent-facing MCP URL = ${layer8}/api/<name><mcp_path>; upstream is the
+    # base, locksmith forwards <mcp_path>.
+    agent_url = f"/api/{name}{tool.mcp_path}"
     args = [
         "tool",
         "put",
         name,
         "--upstream",
-        tool.mcp_url,
+        tool.upstream,
         "--auth",
         f"bearer={KAMIWAZA_PAT_ENV}",
         "--egress",
@@ -329,6 +331,8 @@ def put_registration(name: str, tool: McpTool, dry_run: bool) -> None:
         "--metadata",
         "role=mcp-tool",
         "--metadata",
+        f"mcp_path={tool.mcp_path}",
+        "--metadata",
         f"source={tool.source}",
         "--metadata",
         f"source_id={tool.source_id}",
@@ -336,13 +340,13 @@ def put_registration(name: str, tool: McpTool, dry_run: bool) -> None:
         tool.description[:200],
     ]
     if dry_run:
-        log(f"  [dry-run] put {name} -> {tool.mcp_url}")
+        log(f"  [dry-run] put {name} -> {tool.upstream} (agent MCP: {agent_url})")
         return
     proc = run_locksmith(args)
     if proc.returncode != 0:
         log(f"  FAILED put {name}: {proc.stderr.strip()}")
     else:
-        log(f"  put {name} -> {tool.mcp_url}")
+        log(f"  put {name} -> {tool.upstream} (agent MCP: {agent_url})")
 
 
 def delete_registration(name: str, dry_run: bool) -> None:

--- a/examples/site/scripts/kamiwaza-mcp-registrar.py
+++ b/examples/site/scripts/kamiwaza-mcp-registrar.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""kamiwaza-mcp-registrar — reconcile Kamiwaza-hosted MCP tools into the
+locksmith catalog as ordinary kind=tool registrations.
+
+WHY THIS EXISTS (design, agents-stack ADR-0007 family):
+    Kamiwaza runs MCP tool servers dynamically (Tool Shed deployments +
+    Extensions). We want agents to reach them THROUGH locksmith so the
+    calls inherit locksmith's per-agent ACL, audit, egress (pipelock),
+    and response controls — exactly what a credential proxy is for.
+
+    MCP-over-HTTP is just JSON-RPC over HTTP POST, and Kamiwaza MCP
+    endpoints accept the same Kamiwaza bearer (KAMIWAZA_USE_AUTH=true).
+    So a Kamiwaza MCP tool registered as a normal catalog entry
+    (upstream = the MCP endpoint, auth = bearer=KAMIWAZA_MCP_PAT,
+    egress = direct|proxied) is proxied transparently by locksmith's
+    existing hot path — no locksmith code change, no MCP code in the
+    proxy. MCP-client agents (e.g. hermes) speak MCP straight through
+    /api/<tool>/ and locksmith injects the PAT.
+
+    This registrar is the ONLY Kamiwaza-specific piece: it discovers the
+    live MCP tools and creates/updates/removes their registrations. It
+    runs OFF the hot path (cron / timer), so per-request latency and the
+    SSRF/availability surface of discovery never touch agent traffic.
+
+CREDENTIAL TOPOLOGY:
+    - This script needs KAMIWAZA_MCP_PAT (to call the Kamiwaza discovery
+      API) and the locksmith operator token (to register).
+    - The SAME KAMIWAZA_MCP_PAT must also exist in the locksmith
+      CONTAINER's env (forwarded via docker-compose.override.yml), because
+      the registrations reference `--auth bearer=KAMIWAZA_MCP_PAT` and
+      locksmith resolves env vars from its own process environment at
+      registration time. Put the PAT in the site .env + the override's
+      locksmith environment list, then recreate locksmith before the
+      first run (see README / expose-an-agent.md).
+
+USAGE:
+    KAMIWAZA_API_URL=https://kamiwaza-host \\
+    KAMIWAZA_MCP_PAT=<pat> \\
+    LOCKSMITH_OP_TOKEN=<op-token> \\
+      ./kamiwaza-mcp-registrar.py [--dry-run] [--once]
+
+    Typically invoked from cron via a thin wrapper that decrypts the
+    operator token (see register-agents.sh for the decrypt pattern).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+# ── Configuration (all overridable via env) ──────────────────────────────
+KAMIWAZA_API_URL = os.environ.get("KAMIWAZA_API_URL", "").rstrip("/")
+KAMIWAZA_MCP_PAT = os.environ.get("KAMIWAZA_MCP_PAT", "")
+# Env-var NAME (not value) that locksmith injects as the upstream bearer.
+# Must match a var present in the locksmith container's environment.
+KAMIWAZA_PAT_ENV = os.environ.get("KAMIWAZA_PAT_ENV", "KAMIWAZA_MCP_PAT")
+KAMIWAZA_VERIFY_TLS = os.environ.get("KAMIWAZA_VERIFY_TLS", "true").lower() != "false"
+# Default MCP path when a tool template doesn't declare MCP_PATH.
+DEFAULT_MCP_PATH = os.environ.get("KAMIWAZA_MCP_PATH", "/mcp")
+
+CONTAINER = os.environ.get("CONTAINER", "docker")
+LOCKSMITH_CONTAINER = os.environ.get("LOCKSMITH_CONTAINER", "layer8-locksmith")
+LOCKSMITH_BIN = os.environ.get("LOCKSMITH_BIN", "/usr/local/bin/locksmith")
+LOCKSMITH_OP_TOKEN = os.environ.get("LOCKSMITH_OP_TOKEN", "")
+
+# Registration shape.
+NAME_PREFIX = os.environ.get("KAMIWAZA_NAME_PREFIX", "kamiwaza-")
+# LAN Kamiwaza → direct (lmstudio precedent); internet/proxied Kamiwaza →
+# 'proxied' + a pipelock allowlist entry for the host.
+EGRESS = os.environ.get("KAMIWAZA_EGRESS", "direct")
+# MCP tool calls can be long-running (parsing, inference); size well above
+# the 30s default total-request timeout.
+TIMEOUT_REQUEST = os.environ.get("KAMIWAZA_TIMEOUT_REQUEST", "600")
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def die(msg: str) -> None:
+    log(f"ERROR: {msg}")
+    sys.exit(1)
+
+
+# ── Kamiwaza discovery ────────────────────────────────────────────────────
+
+
+@dataclass
+class McpTool:
+    """A discovered Kamiwaza MCP tool, normalized across Tool Shed and
+    Extensions sources."""
+
+    slug: str  # locksmith registration name suffix ([a-z0-9-])
+    mcp_url: str  # externally-reachable MCP endpoint URL (the upstream)
+    source: str  # "tool-shed" | "extension"
+    source_id: str  # deployment id / extension name (for audit metadata)
+    description: str
+
+
+def _kamiwaza_get(path: str) -> Any:
+    url = f"{KAMIWAZA_API_URL}{path}"
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {KAMIWAZA_MCP_PAT}"}
+    )
+    ctx = None
+    if not KAMIWAZA_VERIFY_TLS:
+        import ssl
+
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None  # endpoint family absent on this instance
+        raise
+
+
+def slugify(name: str) -> str:
+    """Registration name component: lowercase, [a-z0-9-], collapse runs,
+    strip leading/trailing dashes. Mirrors locksmith's name validator
+    ([a-z0-9-], <=64)."""
+    s = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    s = re.sub(r"-{2,}", "-", s)
+    return s or "tool"
+
+
+def _external_mcp_url(base_external: str, mcp_path: str) -> str:
+    """Join a tool's external base URL with its MCP path. An empty
+    mcp_path means MCP is served at the route root (strip_path_prefix
+    tools); return the base with a trailing slash."""
+    base = base_external.rstrip("/")
+    return f"{base}/" if not mcp_path.strip("/") else f"{base}/{mcp_path.lstrip('/')}"
+
+
+_TEMPLATE_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def _tool_templates() -> dict[str, dict[str, Any]]:
+    """Index tool templates by id AND name (for MCP-path resolution).
+    Cached for the run."""
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is None:
+        templates = _kamiwaza_get("/api/tool/templates") or []
+        idx: dict[str, dict[str, Any]] = {}
+        for t in templates:
+            for key in ("id", "name"):
+                if t.get(key):
+                    idx[str(t[key])] = t
+        _TEMPLATE_CACHE = idx
+    return _TEMPLATE_CACHE
+
+
+def _mcp_path_override(slug: str) -> str | None:
+    """Per-tool operator escape hatch: KAMIWAZA_MCP_PATH_<SLUG> env."""
+    return os.environ.get(f"KAMIWAZA_MCP_PATH_{slug.upper().replace('-', '_')}")
+
+
+def resolve_mcp_path(
+    env: dict[str, Any], template: dict[str, Any] | None, override: str | None
+) -> str:
+    """Resolve a tool's MCP sub-path. The MCP mount point is genuinely
+    per-tool — DDE serves MCP at the route ROOT via strip_path_prefix,
+    while omniparse-style tools declare MCP_PATH=/mcp — so this must be
+    resolved, never assumed. Precedence:
+      1. operator override (KAMIWAZA_MCP_PATH_<SLUG>),
+      2. explicit MCP_PATH in the deployment env,
+      3. explicit MCP_PATH in the template env_defaults,
+      4. strip_path_prefix tools → root (empty),
+      5. DEFAULT_MCP_PATH (/mcp)."""
+    if override is not None:
+        return override
+    if "MCP_PATH" in env:
+        return env["MCP_PATH"]
+    tmpl = template or {}
+    tmpl_env = tmpl.get("env_defaults") or {}
+    if "MCP_PATH" in tmpl_env:
+        return tmpl_env["MCP_PATH"]
+    if tmpl.get("strip_path_prefix"):
+        return ""
+    return DEFAULT_MCP_PATH
+
+
+def discover_tool_shed() -> list[McpTool]:
+    """Tool Shed deployments (Docker-Compose-backed). The raw `url` field
+    is node-internal (host.docker.internal:<port>) and NOT reachable from
+    the proxy host; the externally-routable form is the Traefik path
+    <base>/runtime/tools/<deployment-name>/<mcp_path>. Prefer any https
+    external URL the API surfaces; else construct it."""
+    deployments = _kamiwaza_get("/api/tool/deployments") or []
+    tools: list[McpTool] = []
+    for dep in deployments:
+        status = (dep.get("status") or "").lower()
+        if status not in ("running", "deployed"):
+            continue
+        name = dep.get("name") or dep.get("id", "")
+        dep_id = dep.get("id", name)
+        env = dep.get("env_vars") or {}
+        template = _tool_templates().get(str(dep.get("template_id", "")))
+        mcp_path = resolve_mcp_path(env, template, _mcp_path_override(slugify(name)))
+        # Prefer an https external URL if the API provides one; else build
+        # the Traefik runtime route from the deployment name.
+        raw_url = dep.get("url", "")
+        if raw_url.startswith("https://") and "host.docker.internal" not in raw_url:
+            mcp_url = (
+                raw_url
+                if raw_url.rstrip("/").endswith(mcp_path.strip("/"))
+                else _external_mcp_url(raw_url, mcp_path)
+            )
+        else:
+            runtime_name = dep.get("runtime_name") or f"{name}-{dep_id.split('-')[0]}"
+            base = f"{KAMIWAZA_API_URL}/runtime/tools/{runtime_name}"
+            mcp_url = _external_mcp_url(base, mcp_path)
+        tools.append(
+            McpTool(
+                slug=slugify(name),
+                mcp_url=mcp_url,
+                source="tool-shed",
+                source_id=str(dep_id),
+                description=dep.get("description") or f"Kamiwaza Tool Shed MCP: {name}",
+            )
+        )
+    return tools
+
+
+def discover_extensions() -> list[McpTool]:
+    """Extensions (K8s-CR-backed). endpoints.external is API-provided and
+    externally routable; append the tool's MCP_PATH."""
+    extensions = _kamiwaza_get("/api/extensions") or []
+    tools: list[McpTool] = []
+    for ext in extensions:
+        if (ext.get("type") or "") != "tool":
+            continue
+        if (ext.get("phase") or "").lower() != "running":
+            continue
+        name = ext.get("name", "")
+        endpoints = ext.get("endpoints") or {}
+        external = endpoints.get("external")
+        if not external:
+            log(f"  skip extension {name}: no endpoints.external")
+            continue
+        # The Extension schema doesn't carry MCP_PATH; resolve it from the
+        # backing template (strip_path_prefix → root, else MCP_PATH default)
+        # with the per-tool operator override as the escape hatch.
+        template = _tool_templates().get(str(ext.get("template_name", "")))
+        mcp_path = resolve_mcp_path({}, template, _mcp_path_override(slugify(name)))
+        tools.append(
+            McpTool(
+                slug=slugify(name),
+                mcp_url=_external_mcp_url(external, mcp_path),
+                source="extension",
+                source_id=name,
+                description=ext.get("description") or f"Kamiwaza extension MCP: {name}",
+            )
+        )
+    return tools
+
+
+def discover() -> list[McpTool]:
+    tools = discover_tool_shed() + discover_extensions()
+    # De-dupe by registration name (slug); last wins. Extensions are the
+    # newer system, so they sort after Tool Shed and win on collision.
+    by_name: dict[str, McpTool] = {}
+    for t in tools:
+        by_name[f"{NAME_PREFIX}{t.slug}"] = t
+    return list(by_name.values())
+
+
+# ── locksmith catalog reconciliation ──────────────────────────────────────
+
+
+def run_locksmith(args: list[str]) -> subprocess.CompletedProcess:
+    cmd = [
+        CONTAINER,
+        "exec",
+        "-e",
+        f"LOCKSMITH_OP_TOKEN={LOCKSMITH_OP_TOKEN}",
+        LOCKSMITH_CONTAINER,
+        LOCKSMITH_BIN,
+        *args,
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def existing_kamiwaza_registrations() -> set[str]:
+    """Names of current catalog entries this registrar owns (metadata
+    provider=kamiwaza, or the name prefix as a fallback)."""
+    proc = run_locksmith(["tool", "list", "--format", "json"])
+    if proc.returncode != 0:
+        die(f"locksmith tool list failed: {proc.stderr.strip()}")
+    try:
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        die(f"locksmith tool list returned non-JSON: {proc.stdout[:200]}")
+    owned = set()
+    for r in rows:
+        meta = r.get("metadata") or {}
+        if meta.get("provider") == "kamiwaza" or r.get("name", "").startswith(
+            NAME_PREFIX
+        ):
+            owned.add(r["name"])
+    return owned
+
+
+def put_registration(name: str, tool: McpTool, dry_run: bool) -> None:
+    args = [
+        "tool",
+        "put",
+        name,
+        "--upstream",
+        tool.mcp_url,
+        "--auth",
+        f"bearer={KAMIWAZA_PAT_ENV}",
+        "--egress",
+        EGRESS,
+        "--timeout-request",
+        TIMEOUT_REQUEST,
+        "--metadata",
+        "provider=kamiwaza",
+        "--metadata",
+        "role=mcp-tool",
+        "--metadata",
+        f"source={tool.source}",
+        "--metadata",
+        f"source_id={tool.source_id}",
+        "--description",
+        tool.description[:200],
+    ]
+    if dry_run:
+        log(f"  [dry-run] put {name} -> {tool.mcp_url}")
+        return
+    proc = run_locksmith(args)
+    if proc.returncode != 0:
+        log(f"  FAILED put {name}: {proc.stderr.strip()}")
+    else:
+        log(f"  put {name} -> {tool.mcp_url}")
+
+
+def delete_registration(name: str, dry_run: bool) -> None:
+    if dry_run:
+        log(f"  [dry-run] delete {name}")
+        return
+    proc = run_locksmith(["tool", "delete", name])
+    if proc.returncode != 0:
+        log(f"  FAILED delete {name}: {proc.stderr.strip()}")
+    else:
+        log(f"  delete {name} (no longer running in Kamiwaza)")
+
+
+def reconcile(dry_run: bool) -> int:
+    discovered = discover()
+    desired = {f"{NAME_PREFIX}{t.slug}": t for t in discovered}
+    existing = existing_kamiwaza_registrations()
+
+    log(
+        f"discovered {len(desired)} live Kamiwaza MCP tool(s); "
+        f"{len(existing)} currently registered"
+    )
+
+    for name, tool in sorted(desired.items()):
+        put_registration(name, tool, dry_run)
+
+    for name in sorted(existing - set(desired)):
+        delete_registration(name, dry_run)
+
+    log("reconcile complete")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Reconcile Kamiwaza MCP tools into the locksmith catalog."
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show actions without mutating the catalog",
+    )
+    ap.add_argument(
+        "--once",
+        action="store_true",
+        help="run a single reconcile pass (default; cron drives repetition)",
+    )
+    args = ap.parse_args()
+
+    if not KAMIWAZA_API_URL:
+        die("KAMIWAZA_API_URL is required")
+    if not KAMIWAZA_MCP_PAT:
+        die("KAMIWAZA_MCP_PAT is required (Kamiwaza discovery bearer)")
+    if not KAMIWAZA_VERIFY_TLS:
+        log(
+            "WARNING: KAMIWAZA_VERIFY_TLS=false — discovery calls skip cert "
+            "verification (MITM-exposed). Dev/self-signed only; in production "
+            "add the Kamiwaza CA to the trust store or use a real cert. This "
+            "affects ONLY this registrar's discovery; locksmith still verifies "
+            "the MCP upstream when proxying agent traffic."
+        )
+    if not LOCKSMITH_OP_TOKEN and not args.dry_run:
+        die("LOCKSMITH_OP_TOKEN is required to register (or use --dry-run)")
+
+    return reconcile(args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Makes Kamiwaza-hosted MCP tools reachable by agents **through locksmith**, as ordinary `kind=tool` catalog registrations fed by an off-hot-path **registrar**. Zero locksmith code change — Kamiwaza MCP tools inherit per-agent ACL, audit, egress (pipelock), and response controls because they flow through the existing registration plane.

- `examples/site/scripts/kamiwaza-mcp-registrar.py` — discovers live MCP tools (`/api/tool/deployments` + `/api/extensions`), resolves each external Traefik MCP URL + per-tool MCP path, reconciles them into the catalog idempotently (add/update running, remove stopped), tagged `provider=kamiwaza`.
- `docs/user/kamiwaza-mcp.md` — architecture, PAT plumbing, cron wiring, per-tool MCP-path resolution.

## Why this supersedes agent-locksmith #89

#89 put a Kamiwaza-specific provider on locksmith's **hot path** and re-implemented (and partly skipped) audit/egress/size-cap/caching. An [adversarial review](.) of #89 found: audit bypass, SSRF on discovered URLs, no response size cap, per-request discovery, SecretString→String, and catalog bypass — **all symptoms of living in the wrong layer**. Recon of the live Kamiwaza API confirmed MCP-over-HTTP is forwardable HTTP with a shared bearer, so the registrar model resolves every finding structurally and keeps locksmith vendor-neutral. #89's translation behavior (non-MCP agents calling MCP tools as REST) was deliberately **not** adopted — our agents are MCP clients.

## Validation status

- **Locksmith passthrough**: verified by header-strip analysis (PAT injects as Authorization; `Mcp-Session-Id` + `text/event-stream` round-trip; SSE streams; codex fixup doesn't interfere). No code change needed.
- **Registrar logic**: unit-tested (MCP-path precedence, URL join, slug).
- **Live end-to-end against Kamiwaza**: ⛔ **blocked** — the only MCP-native tool on the test instance (`kamiwaza-dde`) can't pull its private GHCR image (`dde:develop`); omniparse 2.2.0 is MCP-tagged but REST-only. Needs GHCR auth on the Kamiwaza host or a public MCP image. Draft until validated live.

Co-authored-by: Matt Wallace <916184+m9e@users.noreply.github.com>